### PR TITLE
add branch field

### DIFF
--- a/packlist
+++ b/packlist
@@ -2,6 +2,7 @@ name = ufsos
     type = github
         author = MrObsidy
         repository = UFSOS
+        branch = master
     category = os
     dependencies = lyqyd/packman lyqyd/netshell
     target = /


### PR DESCRIPTION
The github download type requires a branch field as of a while back. Your package specification was missing this field, so I've added it.<br />